### PR TITLE
Switched compatibility from ESP32-WROOM-DEV to ESP32-S3. Added compatibility for all sensors on custom breakout board.

### DIFF
--- a/boards/esp32-s3-devkitc-1-n16r8v.json
+++ b/boards/esp32-s3-devkitc-1-n16r8v.json
@@ -1,0 +1,53 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32s3_out.ld",
+        "partitions": "default_16MB.csv",
+        "memory_type": "qio_opi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DARDUINO_ESP32S3_DEV",
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_USB_MODE=1",
+        "-DARDUINO_USB_CDC_ON_BOOT=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "psram_type": "opi",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "esp32s3"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Espressif ESP32-S3-DevKitC-1-N16R8V (16 MB QD, 8MB PSRAM)",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 16777216,
+      "require_upload_port": true,
+      "speed": 921600
+    },
+    "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+    "vendor": "Espressif"
+  }

--- a/include/DOSensor.h
+++ b/include/DOSensor.h
@@ -17,7 +17,7 @@ class DOSensor    {
         static DOSensor& get();
         void begin();
         bool readDO(float* DO, float salinity, float temp);
-        static constexpr short EN_O = 26;  //used to turn off the circuit to save power (~2.9mA)
+        static constexpr short EN_O = 38;  //used to turn off the circuit to save power (~2.9mA)
 
 
     private:

--- a/include/DOSensor.h
+++ b/include/DOSensor.h
@@ -17,6 +17,7 @@ class DOSensor    {
         static DOSensor& get();
         void begin();
         bool readDO(float* DO, float salinity, float temp);
+        static constexpr short EN_O = 26;  //used to turn off the circuit to save power (~2.9mA)
 
 
     private:

--- a/include/SalinitySensor.h
+++ b/include/SalinitySensor.h
@@ -17,6 +17,7 @@ public:
     bool readTDS(float* tds);
     bool readEC(float* ec);
     void DisableAllReadings();
+    void calibrate();
     void sleep();
     static constexpr short EN_S = 25;
 

--- a/include/SalinitySensor.h
+++ b/include/SalinitySensor.h
@@ -26,8 +26,6 @@ private:
     Ezo_board ec = Ezo_board(EC_ADDR, ecName.c_str());
     char ec_data[32];
 
-    
-
     static constexpr uint8_t TEMP_COMP = 25;
     static constexpr uint8_t K_FACTOR = 1;
     bool salFlag = false;

--- a/include/SalinitySensor.h
+++ b/include/SalinitySensor.h
@@ -19,7 +19,7 @@ public:
     void DisableAllReadings();
     void calibrate();
     void sleep();
-    static constexpr short EN_S = 25;
+    static constexpr short EN_S = 38;
 
 private:
     String ecName = "SAL";

--- a/include/SalinitySensor.h
+++ b/include/SalinitySensor.h
@@ -17,13 +17,15 @@ public:
     bool readTDS(float* salinity);
     void DisableAllReadings();
     void sleep();
-    
+    static constexpr short EN_S = 25;
 
 private:
     String ecName = "SAL";
     static constexpr short EC_ADDR = 0x14;
     Ezo_board ec = Ezo_board(EC_ADDR, ecName.c_str());
     char ec_data[32];
+
+    
 
     static constexpr uint8_t TEMP_COMP = 25;
     static constexpr uint8_t K_FACTOR = 1;

--- a/include/SalinitySensor.h
+++ b/include/SalinitySensor.h
@@ -14,7 +14,8 @@ public:
     void begin();
     void EnableDisableSingleReading(uint8_t readOption, uint8_t data);
     bool readSalinity(float* salinity);
-    bool readTDS(float* salinity);
+    bool readTDS(float* tds);
+    bool readEC(float* ec);
     void DisableAllReadings();
     void sleep();
     static constexpr short EN_S = 25;

--- a/include/TempSensor.h
+++ b/include/TempSensor.h
@@ -13,8 +13,8 @@ enum TEMP {CELSIUS,FAHRENHEIT};
 class TempSensor
 {
 public:
-    static constexpr uint8_t ONE_WIRE_BUS = 33;
-    static constexpr uint8_t DHTPIN = 4;
+    static constexpr uint8_t ONE_WIRE_BUS = 41;
+    static constexpr uint8_t DHTPIN = 42;
     static constexpr uint8_t DHTTYPE = DHT22;
     static constexpr uint8_t TEMP_INDEX = 0;
 

--- a/include/TempSensor.h
+++ b/include/TempSensor.h
@@ -3,7 +3,8 @@
 #include <DHT.h>
 
 #include <OneWire.h>
-#include <DallasTemperature.h>
+//#include <DallasTemperature.h>
+#include "dallasTemperature.h"
 
 
 
@@ -18,17 +19,21 @@ public:
     static constexpr uint8_t DHTTYPE = DHT22;
     static constexpr uint8_t TEMP_INDEX = 0;
 
+
     static TempSensor& Get();
     void begin();
     bool readTemperature(TEMP tempScale, float* temperature);
+    bool readTemp(TEMP tempScale, float* temperature);
     bool readHumidity(float* humidity);
+    int findDevices();
+
 
 private:
     TempSensor();
     DHT dht;
     OneWire oneWire;
-    DallasTemperature sensors;
-    
+    DallasTemperature sensors;    
+
     //making it signletton
     TempSensor (const TempSensor&) = delete;
     TempSensor& operator=(const TempSensor&)=delete; 

--- a/include/TurbiditySensor.h
+++ b/include/TurbiditySensor.h
@@ -7,9 +7,9 @@
 class TurbiditySensor {
 public:
     static constexpr short READ_SAMPLES = 25;
-    static constexpr short T_ANALOG_PIN = 32; // ADC1 pin
+    static constexpr short T_ANALOG_PIN = 2; // ADC1 pin
     static constexpr uint8_t EEPROM_VCLEAR_ADDRESS = 0;
-    static constexpr uint8_t EN = 12;
+    static constexpr uint8_t EN = 39;
 
     static TurbiditySensor& Get();
     void begin();

--- a/include/dallasTemperature.h
+++ b/include/dallasTemperature.h
@@ -1,0 +1,346 @@
+#ifndef dallasTemperature_h
+#define dallasTemperature_h
+
+#define DALLASTEMPLIBVERSION "3.8.1" // To be deprecated -> TODO remove in 4.0.0
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// set to true to include code for new and delete operators
+#ifndef REQUIRESNEW
+#define REQUIRESNEW false
+#endif
+
+// set to true to include code implementing alarm search functions
+#ifndef REQUIRESALARMS
+#define REQUIRESALARMS true
+#endif
+
+#include <inttypes.h>
+#ifdef __STM32F1__
+#include <OneWireSTM.h>
+#else
+#include <OneWire.h>
+#endif
+
+// Model IDs
+#define DS18S20MODEL 0x10  // also DS1820
+#define DS18B20MODEL 0x28  // also MAX31820
+#define DS1822MODEL  0x22
+#define DS1825MODEL  0x3B  // also MAX31850
+#define DS28EA00MODEL 0x42
+
+// Error Codes
+// See https://github.com/milesburton/Arduino-Temperature-Control-Library/commit/ac1eb7f56e3894e855edc3353be4bde4aa838d41#commitcomment-75490966 for the 16bit implementation. Reverted due to microcontroller resource constraints.
+#define DEVICE_DISCONNECTED_C -127
+#define DEVICE_DISCONNECTED_F -196.6
+#define DEVICE_DISCONNECTED_RAW -7040
+
+#define DEVICE_FAULT_OPEN_C -254
+#define DEVICE_FAULT_OPEN_F -425.199982
+#define DEVICE_FAULT_OPEN_RAW -32512
+
+#define DEVICE_FAULT_SHORTGND_C -253
+#define DEVICE_FAULT_SHORTGND_F -423.399994
+#define DEVICE_FAULT_SHORTGND_RAW -32384
+
+#define DEVICE_FAULT_SHORTVDD_C -252
+#define DEVICE_FAULT_SHORTVDD_F -421.599976
+#define DEVICE_FAULT_SHORTVDD_RAW -32256
+
+// For readPowerSupply on oneWire bus
+// definition of nullptr for C++ < 11, using official workaround:
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf
+#if __cplusplus < 201103L
+const class
+{
+public:
+	template <class T>
+	operator T *() const {
+		return 0;
+	}
+
+	template <class C, class T>
+	operator T C::*() const {
+		return 0;
+	}
+
+private:
+	void operator&() const;
+} nullptr = {};
+#endif
+
+typedef uint8_t DeviceAddress[8];
+
+class DallasTemperature {
+public:
+
+	DallasTemperature();
+	DallasTemperature(OneWire*);
+	DallasTemperature(OneWire*, uint8_t);
+
+	void setOneWire(OneWire*);
+
+	void setPullupPin(uint8_t);
+
+	// initialise bus
+	void begin(void);
+
+	// returns the number of devices found on the bus
+	uint8_t getDeviceCount(void);
+
+	// returns the number of DS18xxx Family devices on bus
+	uint8_t getDS18Count(void);
+
+	// returns true if address is valid
+	bool validAddress(const uint8_t*);
+
+	// returns true if address is of the family of sensors the lib supports.
+	bool validFamily(const uint8_t* deviceAddress);
+
+	// finds an address at a given index on the bus
+	bool getAddress(uint8_t*, uint8_t);
+
+	// attempt to determine if the device at the given address is connected to the bus
+	bool isConnected(const uint8_t*);
+
+	// attempt to determine if the device at the given address is connected to the bus
+	// also allows for updating the read scratchpad
+	bool isConnected(const uint8_t*, uint8_t*);
+
+	// read device's scratchpad
+	bool readScratchPad(const uint8_t*, uint8_t*);
+
+	// write device's scratchpad
+	void writeScratchPad(const uint8_t*, const uint8_t*);
+
+	// read device's power requirements
+	bool readPowerSupply(const uint8_t* deviceAddress = nullptr);
+
+	// get global resolution
+	uint8_t getResolution();
+
+	// set global resolution to 9, 10, 11, or 12 bits
+	void setResolution(uint8_t);
+
+	// returns the device resolution: 9, 10, 11, or 12 bits
+	uint8_t getResolution(const uint8_t*);
+
+	// set resolution of a device to 9, 10, 11, or 12 bits
+	bool setResolution(const uint8_t*, uint8_t,
+	                   bool skipGlobalBitResolutionCalculation = false);
+
+	// sets/gets the waitForConversion flag
+	void setWaitForConversion(bool);
+	bool getWaitForConversion(void);
+
+	// sets/gets the checkForConversion flag
+	void setCheckForConversion(bool);
+	bool getCheckForConversion(void);
+
+	struct request_t {
+		bool result;
+		unsigned long timestamp;
+
+		operator bool() {
+			return result;
+		}
+	};
+
+	// sends command for all devices on the bus to perform a temperature conversion
+	request_t requestTemperatures(void);
+
+	// sends command for one device to perform a temperature conversion by address
+	request_t requestTemperaturesByAddress(const uint8_t*);
+
+	// sends command for one device to perform a temperature conversion by index
+	request_t requestTemperaturesByIndex(uint8_t);
+
+	// returns temperature raw value (12 bit integer of 1/128 degrees C)
+	int32_t getTemp(const uint8_t*);
+
+	// returns temperature in degrees C
+	float getTempC(const uint8_t*);
+
+	// returns temperature in degrees F
+	float getTempF(const uint8_t*);
+
+	// Get temperature for device index (slow)
+	float getTempCByIndex(uint8_t);
+
+	// Get temperature for device index (slow)
+	float getTempFByIndex(uint8_t);
+
+	// returns true if the bus requires parasite power
+	bool isParasitePowerMode(void);
+
+	// Is a conversion complete on the wire? Only applies to the first sensor on the wire.
+	bool isConversionComplete(void);
+
+	static uint16_t millisToWaitForConversion(uint8_t);
+
+	uint16_t millisToWaitForConversion();
+
+	// Sends command to one device to save values from scratchpad to EEPROM by index
+	// Returns true if no errors were encountered, false indicates failure
+	bool saveScratchPadByIndex(uint8_t);
+
+	// Sends command to one or more devices to save values from scratchpad to EEPROM
+	// Returns true if no errors were encountered, false indicates failure
+	bool saveScratchPad(const uint8_t* = nullptr);
+
+	// Sends command to one device to recall values from EEPROM to scratchpad by index
+	// Returns true if no errors were encountered, false indicates failure
+	bool recallScratchPadByIndex(uint8_t);
+
+	// Sends command to one or more devices to recall values from EEPROM to scratchpad
+	// Returns true if no errors were encountered, false indicates failure
+	bool recallScratchPad(const uint8_t* = nullptr);
+
+	// Sets the autoSaveScratchPad flag
+	void setAutoSaveScratchPad(bool);
+
+	// Gets the autoSaveScratchPad flag
+	bool getAutoSaveScratchPad(void);
+
+#if REQUIRESALARMS
+
+	typedef void AlarmHandler(const uint8_t*);
+
+	// sets the high alarm temperature for a device
+	// accepts a int8_t.  valid range is -55C - 125C
+	void setHighAlarmTemp(const uint8_t*, int8_t);
+
+	// sets the low alarm temperature for a device
+	// accepts a int8_t.  valid range is -55C - 125C
+	void setLowAlarmTemp(const uint8_t*, int8_t);
+
+	// returns a int8_t with the current high alarm temperature for a device
+	// in the range -55C - 125C
+	int8_t getHighAlarmTemp(const uint8_t*);
+
+	// returns a int8_t with the current low alarm temperature for a device
+	// in the range -55C - 125C
+	int8_t getLowAlarmTemp(const uint8_t*);
+
+	// resets internal variables used for the alarm search
+	void resetAlarmSearch(void);
+
+	// search the wire for devices with active alarms
+	bool alarmSearch(uint8_t*);
+
+	// returns true if ia specific device has an alarm
+	bool hasAlarm(const uint8_t*);
+
+	// returns true if any device is reporting an alarm on the bus
+	bool hasAlarm(void);
+
+	// runs the alarm handler for all devices returned by alarmSearch()
+	void processAlarms(void);
+
+	// sets the alarm handler
+	void setAlarmHandler(const AlarmHandler *);
+
+	// returns true if an AlarmHandler has been set
+	bool hasAlarmHandler();
+
+#endif
+
+	// if no alarm handler is used the two bytes can be used as user data
+	// example of such usage is an ID.
+	// note if device is not connected it will fail writing the data.
+	// note if address cannot be found no error will be reported.
+	// in short use carefully
+	void setUserData(const uint8_t*, int16_t);
+	void setUserDataByIndex(uint8_t, int16_t);
+	int16_t getUserData(const uint8_t*);
+	int16_t getUserDataByIndex(uint8_t);
+
+	// convert from Celsius to Fahrenheit
+	static float toFahrenheit(float);
+
+	// convert from Fahrenheit to Celsius
+	static float toCelsius(float);
+
+	// convert from raw to Celsius
+	static float rawToCelsius(int32_t);
+
+	// convert from Celsius to raw
+	static int16_t celsiusToRaw(float);
+
+	// convert from raw to Fahrenheit
+	static float rawToFahrenheit(int32_t);
+
+#if REQUIRESNEW
+
+	// initialize memory area
+	void* operator new(unsigned int);
+
+	// delete memory reference
+	void operator delete(void*);
+
+#endif
+
+	void blockTillConversionComplete(uint8_t);
+	void blockTillConversionComplete(uint8_t, unsigned long);
+	void blockTillConversionComplete(uint8_t, request_t);
+
+private:
+	typedef uint8_t ScratchPad[9];
+
+	// parasite power on or off
+	bool parasite;
+
+	// external pullup
+	bool useExternalPullup;
+	uint8_t pullupPin;
+
+	// used to determine the delay amount needed to allow for the
+	// temperature conversion to take place
+	uint8_t globalBitResolution;
+
+	// used to requestTemperature with or without delay
+	bool waitForConversion;
+
+	// used to requestTemperature to dynamically check if a conversion is complete
+	bool checkForConversion;
+
+	// used to determine if values will be saved from scratchpad to EEPROM on every scratchpad write
+	bool autoSaveScratchPad;
+
+	// count of devices on the bus
+	uint8_t devices;
+
+	// count of DS18xxx Family devices on bus
+	uint8_t ds18Count;
+
+	// Take a pointer to one wire instance
+	OneWire* _wire;
+
+	// reads scratchpad and returns the raw temperature
+	int32_t calculateTemperature(const uint8_t*, uint8_t*);
+
+
+	// Returns true if all bytes of scratchPad are '\0'
+	bool isAllZeros(const uint8_t* const scratchPad, const size_t length = 9);
+
+	// External pullup control
+	void activateExternalPullup(void);
+	void deactivateExternalPullup(void);
+
+#if REQUIRESALARMS
+
+	// required for alarmSearch
+	uint8_t alarmSearchAddress[8];
+	int8_t alarmSearchJunction;
+	uint8_t alarmSearchExhausted;
+
+	// the alarm handler function pointer
+	AlarmHandler *_AlarmHandler;
+
+#endif
+
+};
+#endif

--- a/include/ioExtender.h
+++ b/include/ioExtender.h
@@ -1,0 +1,25 @@
+#ifndef IOEXTENDER_H
+#define IOEXTENDER_H
+
+#include "Adafruit_MCP23X17.h"
+
+class MCP   {
+    public:
+        void begin();
+        void pinMode(int pin, uint8_t mode);
+        void digitalWrite(uint8_t pin, uint8_t value);
+        uint8_t digitalRead(uint8_t pin);
+        static MCP& Get();
+
+    private:
+        
+        Adafruit_MCP23X17 mcp;
+        MCP();
+        MCP(const MCP&) = delete;
+        MCP& operator=(const MCP&) = delete;
+
+};
+
+extern MCP& mcpGlobal;
+
+#endif

--- a/include/io_handler.h
+++ b/include/io_handler.h
@@ -15,6 +15,8 @@
 // #include <base_surveyor.h>
 #include "DOSensor.h"
 
+
+
 struct SensorData {
     float humidity;
     bool humidityValid  = true;

--- a/include/io_handler.h
+++ b/include/io_handler.h
@@ -28,6 +28,8 @@ struct SensorData {
     bool salinityValid= true;
     float tds;
     bool tdsValid= true;
+    float ec;
+    bool ecValid = true;
     float pH ;
     bool pHValid= true;
     float oxygenLevel;

--- a/include/io_handler.h
+++ b/include/io_handler.h
@@ -5,6 +5,7 @@
 #include <Arduino.h>
 #include <time.h>
 #include "SdFat.h"
+#include <SD_MMC.h>
 
 #include <ArduinoJson.h>
 
@@ -14,6 +15,13 @@
 #include "pHSensor.h"
 // #include <base_surveyor.h>
 #include "DOSensor.h"
+
+#define IO_RXD2 47
+#define IO_TXD2 48
+
+#define PIN_SD_CMD 11
+#define PIN_SD_CLK 12
+#define PIN_SD_D0 13
 
 
 
@@ -45,11 +53,11 @@ bool uploadData(String jsonData);
 
 //json
 String prepareJsonPayload(const SensorData& data);
-bool saveJsonData(SdFat32 &SD, const String &data);
+bool saveJsonData(fs::FS &fs, const String &data);
 //csv
 String prepareCSVPayload(const SensorData& data);
-bool saveCSVData(SdFat32 &SD, const String& data);
-String readDataFromSD(SdFat32 &SD, const char* fileName);
+bool saveCSVData(fs::FS &fs, const String& data);
+String readDataFromSD(fs::FS &fs, const char* fileName);
 
 bool is_time_synced();
 

--- a/include/io_handler.h
+++ b/include/io_handler.h
@@ -28,7 +28,7 @@
 struct SensorData {
     float humidity;
     bool humidityValid  = true;
-    float temperature ;
+    float temperature;
     bool temperatureValid= true;
     float turbidity;
     bool turbidityValid= true;

--- a/include/library.json
+++ b/include/library.json
@@ -1,0 +1,38 @@
+{
+  "name": "DallasTemperature",
+  "keywords": "onewire, 1-wire, bus, sensor, temperature",
+  "description": "Arduino Library for Dallas Temperature ICs (DS18B20, DS18S20, DS1822, DS1820, MAX31850)",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/milesburton/Arduino-Temperature-Control-Library.git"
+  },
+  "authors": 
+  [
+    {
+      "name": "Miles Burton",
+      "email": "miles@mnetcs.com",
+      "url": "http://www.milesburton.com",
+      "maintainer": true
+    },
+    {
+      "name": "Tim Newsome",
+      "email": "nuisance@casualhacker.net"
+    },
+    {
+      "name": "Guil Barros",
+      "email": "gfbarros@bappos.com"
+    },
+    {
+      "name": "Rob Tillaart",
+      "email": "rob.tillaart@gmail.com"
+    }
+  ],
+  "dependencies":
+  {
+    "pstolarz/OneWireNg": ">=0.10.0"
+  },
+  "version": "3.11.0",
+  "frameworks": "arduino",
+  "platforms": "*"
+}

--- a/include/library.properties
+++ b/include/library.properties
@@ -1,0 +1,10 @@
+name=DallasTemperature
+version=3.11.0
+author=Miles Burton <miles@mnetcs.com>, Tim Newsome <nuisance@casualhacker.net>, Guil Barros <gfbarros@bappos.com>, Rob Tillaart <rob.tillaart@gmail.com>
+maintainer=Miles Burton <miles@mnetcs.com>
+sentence=Arduino Library for Dallas Temperature ICs
+paragraph=Supports DS18B20, DS18S20, DS1822, DS1820, MAX31850
+category=Sensors
+url=https://github.com/milesburton/Arduino-Temperature-Control-Library
+architectures=*
+depends=OneWireNg

--- a/include/pHSensor.h
+++ b/include/pHSensor.h
@@ -13,7 +13,7 @@ class pHSensor {
 public:
     static constexpr uint8_t EEPROM_VCLEAR_ADDRESS = 0;
     static constexpr uint8_t PIN = 1;
-    static constexpr uint8_t EN = 40;
+    static constexpr uint8_t EN = 39;
 
     static pHSensor& Get();
     void begin();

--- a/include/pHSensor.h
+++ b/include/pHSensor.h
@@ -12,8 +12,8 @@
 class pHSensor {
 public:
     static constexpr uint8_t EEPROM_VCLEAR_ADDRESS = 0;
-    static constexpr uint8_t PIN = 35;
-    static constexpr uint8_t EN = 14;
+    static constexpr uint8_t PIN = 1;
+    static constexpr uint8_t EN = 40;
 
     static pHSensor& Get();
     void begin();

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; PlatformIO Project Configuration File
+ PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
- PlatformIO Project Configuration File
+; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,11 +19,13 @@ lib_deps =
 	adafruit/Adafruit Unified Sensor@^1.1.14
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	paulstoffregen/OneWire@^2.3.8
-	milesburton/DallasTemperature@^3.11.0
 	bblanchon/ArduinoJson@^7.0.4
 	mulmer89/EZO I2C Sensors@2.0.0+640de15
 	links2004/WebSockets@^2.4.2
-
-	; peterus/ESP-FTP-Server-Lib@^0.14.1
 	adafruit/SdFat - Adafruit Fork@^2.2.3
 	arduino-libraries/NTPClient@^3.2.1
+	milesburton/DallasTemperature@^3.11.0
+	pstolarz/OneWireNg@^0.13.3
+	adafruit/Adafruit MCP23017 Arduino Library@^2.3.2
+	adafruit/Adafruit BusIO@^1.16.2
+	espressif/esp32-camera@^2.0.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [env:esp32dev]
 platform = espressif32
-board = esp32dev
+board = esp32-s3-devkitc-1-n16r8v
 monitor_speed = 115200
 framework = arduino
 board_build.partitions = min_spiffs.csv

--- a/src/Adapters/DOSensor.cpp
+++ b/src/Adapters/DOSensor.cpp
@@ -13,8 +13,8 @@ DOSensor &DOSensor::get()
 
 void DOSensor::begin()
 {   
-    pinMode(EN_O, OUTPUT);
-    digitalWrite(EN_O, HIGH);
+    //pinMode(EN_O, OUTPUT);
+    //digitalWrite(EN_O, HIGH);
     int calibrated = 0, tempComp = 0, salComp = 0;
     char parsedData[32];
     delay(500);
@@ -61,7 +61,7 @@ void DOSensor::begin()
 
 bool DOSensor::readDO(float* DO, float salinity, float temp) {
 
-    digitalWrite(EN_O, HIGH);
+    //digitalWrite(EN_O, HIGH);
     delay(300);
     //must send salinity and temp for proper reading
     String command = "S," + String(salinity) + ",ppt";

--- a/src/Adapters/DOSensor.cpp
+++ b/src/Adapters/DOSensor.cpp
@@ -12,7 +12,9 @@ DOSensor &DOSensor::get()
 }
 
 void DOSensor::begin()
-{
+{   
+    pinMode(EN_O, OUTPUT);
+    digitalWrite(EN_O, HIGH);
     int calibrated = 0, tempComp = 0, salComp = 0;
     char parsedData[32];
     delay(500);
@@ -54,6 +56,8 @@ void DOSensor::begin()
 
 bool DOSensor::readDO(float* DO, float salinity, float temp) {
 
+    digitalWrite(EN_O, HIGH);
+    delay(300);
     //must send salinity and temp for proper reading
     String command = "S," + String(salinity) + ",ppt";
     ec2.send_cmd(command.c_str());
@@ -67,6 +71,7 @@ bool DOSensor::readDO(float* DO, float salinity, float temp) {
     ec2.receive_cmd(ec_data, sizeof(ec_data));
     ec2.send_cmd("Sleep");
     delay(300);
+    digitalWrite(EN_O, LOW);
     // Serial.print("RAW salinity Read: ");
     // Serial.println(ec_data);
 

--- a/src/Adapters/DOSensor.cpp
+++ b/src/Adapters/DOSensor.cpp
@@ -19,10 +19,15 @@ void DOSensor::begin()
     char parsedData[32];
     delay(500);
 
-     if (parseValue(ec_data, parsedData, "?Cal")) {
-        Serial.println("Calibration profile detected.");
-        calibrated = (atoi(parsedData) != 0);
-    }
+    // if (parseValue(ec_data, parsedData, "?Cal")) {
+    //     Serial.println("Calibration profile detected.");
+    //     calibrated = (atoi(parsedData) != 0);
+    // }
+
+    // Sends a calibration command to calibrate DO to atmospheric oxygen levels
+    // ec2.send_cmd("Cal");
+    // delay(1300);
+    // Serial.println("DO Calibration Complete")
 
     ec2.send_cmd("T,?");
     delay(500);

--- a/src/Adapters/DOSensor.cpp
+++ b/src/Adapters/DOSensor.cpp
@@ -13,8 +13,8 @@ DOSensor &DOSensor::get()
 
 void DOSensor::begin()
 {   
-    //pinMode(EN_O, OUTPUT);
-    //digitalWrite(EN_O, HIGH);
+    pinMode(EN_O, OUTPUT);
+    digitalWrite(EN_O, HIGH);
     int calibrated = 0, tempComp = 0, salComp = 0;
     char parsedData[32];
     delay(500);
@@ -61,7 +61,7 @@ void DOSensor::begin()
 
 bool DOSensor::readDO(float* DO, float salinity, float temp) {
 
-    //digitalWrite(EN_O, HIGH);
+    digitalWrite(EN_O, HIGH);
     delay(300);
     //must send salinity and temp for proper reading
     String command = "S," + String(salinity) + ",ppt";
@@ -76,7 +76,7 @@ bool DOSensor::readDO(float* DO, float salinity, float temp) {
     ec2.receive_cmd(ec_data, sizeof(ec_data));
     ec2.send_cmd("Sleep");
     delay(300);
-    digitalWrite(EN_O, LOW);
+    //digitalWrite(EN_O, LOW);
     // Serial.print("RAW salinity Read: ");
     // Serial.println(ec_data);
 

--- a/src/Adapters/SalinitySensor.cpp
+++ b/src/Adapters/SalinitySensor.cpp
@@ -10,6 +10,7 @@ void SalinitySensor::begin() {
     bool calibrated, tempComp, kFactor;
     char parsedData[32];
     delay(500);
+    digitalWrite(EN_S, HIGH);
 
     ec.send_cmd("Cal,?");
     delay(500);
@@ -99,7 +100,9 @@ bool SalinitySensor::readSalinity(float* salinity) {
     //     EnableDisableSingleReading(SAL, 1);
 
     // }
-
+    pinMode(EN_S, OUTPUT);
+    digitalWrite(EN_S, HIGH);
+    delay(1200);
     ec.send_cmd("R");
     delay(600);
     ec.receive_cmd(ec_data, sizeof(ec_data));
@@ -121,6 +124,8 @@ bool SalinitySensor::readTDS(float* salinity){
     EnableDisableSingleReading(SAL, 0);
     EnableDisableSingleReading(TDS, 1);
 
+    digitalWrite(EN_S, HIGH);
+    delay(600);
     ec.send_cmd("R");
     delay(600);
     ec.receive_cmd(ec_data, sizeof(ec_data));
@@ -183,4 +188,6 @@ SalinitySensor& SalinitySensor::Get() {
 void SalinitySensor::sleep() {
     ec.send_cmd("Sleep");
     delay(300);
+    digitalWrite(EN_S, LOW);
+
 }

--- a/src/Adapters/SalinitySensor.cpp
+++ b/src/Adapters/SalinitySensor.cpp
@@ -13,16 +13,6 @@ void SalinitySensor::begin() {
     //pinMode(EN_S, OUTPUT);
     //digitalWrite(EN_S, HIGH);
     
-    // 2 Step Calibration Code 
-    // Serial.println("Starting Salnity Dry Calibration");
-    // ec.send_cmd("Cal, dry"); 
-    // delay(600);
-    // Serial.println("Finishes, 3 seconds to switch to 80,000");
-    // delay(5000);
-    // ec.send_cmd("Cal, 12880");
-    // delay(600);
-    // Serial.println("Salinity Calibration Complete!");
-
     ec.send_cmd("Cal,?");
     delay(500);
     ec.receive_cmd(ec_data, sizeof(ec_data));
@@ -171,6 +161,28 @@ bool SalinitySensor::readEC(float* salinity){
     return false;
 }
 
+void SalinitySensor::calibrate()    {
+
+    Serial.println("Clearing previous calibration...");
+    ec.send_cmd("Cal,clear");
+    delay(300);
+    // 2 Step Calibration Code 
+    Serial.println("Starting Salnity Dry Calibration");
+    ec.send_cmd("Cal,dry"); 
+    delay(600);
+    Serial.println("Finished, 10 seconds to switch to 12,880 low point calibration");
+    delay(10000);
+    ec.send_cmd("Cal,low,12880");
+    delay(600);
+    Serial.println("Finished low point, 10 seconds to switch to 80,000 high point calibration");
+    delay(10000);
+    ec.send_cmd("Cal,high,80000");
+    delay(600);
+    Serial.println("Salinity Calibration Complete!");
+
+
+}
+
 void SalinitySensor::DisableAllReadings() {
     ec.send_cmd("O,EC,0");
     delay(500);
@@ -183,6 +195,8 @@ void SalinitySensor::DisableAllReadings() {
     delay(500);
     Serial.println("Cleared Readings.");
 }
+
+
 
 bool SalinitySensor::parseValue(const char* rawBuff, char* parsedBuff, const char* key) {
     const char* found = strstr(rawBuff, key);

--- a/src/Adapters/SalinitySensor.cpp
+++ b/src/Adapters/SalinitySensor.cpp
@@ -10,8 +10,9 @@ void SalinitySensor::begin() {
     bool calibrated, tempComp, kFactor;
     char parsedData[32];
     delay(500);
-    digitalWrite(EN_S, HIGH);
-
+    //pinMode(EN_S, OUTPUT);
+    //digitalWrite(EN_S, HIGH);
+    
     // 2 Step Calibration Code 
     // Serial.println("Starting Salnity Dry Calibration");
     // ec.send_cmd("Cal, dry"); 
@@ -113,8 +114,8 @@ bool SalinitySensor::readSalinity(float* salinity) {
     //     EnableDisableSingleReading(SAL, 1);
 
     // }
-    pinMode(EN_S, OUTPUT);
-    digitalWrite(EN_S, HIGH);
+    //pinMode(EN_S, OUTPUT);
+    //digitalWrite(EN_S, HIGH);
     delay(1200);
     ec.send_cmd("R");
     delay(600);
@@ -137,7 +138,7 @@ bool SalinitySensor::readTDS(float* salinity){
     EnableDisableSingleReading(SAL, 0);
     EnableDisableSingleReading(TDS, 1);
 
-    digitalWrite(EN_S, HIGH);
+    //digitalWrite(EN_S, HIGH);
     delay(600);
     ec.send_cmd("R");
     delay(600);
@@ -157,7 +158,7 @@ bool SalinitySensor::readEC(float* salinity){
     EnableDisableSingleReading(EC, 0);
     EnableDisableSingleReading(EC, 1);
 
-    digitalWrite(EN_S, HIGH);
+    //digitalWrite(EN_S, HIGH);
     delay(600);
     ec.send_cmd("R");
     delay(600);
@@ -221,6 +222,6 @@ SalinitySensor& SalinitySensor::Get() {
 void SalinitySensor::sleep() {
     ec.send_cmd("Sleep");
     delay(300);
-    digitalWrite(EN_S, LOW);
+    //digitalWrite(EN_S, LOW);
 
 }

--- a/src/Adapters/SalinitySensor.cpp
+++ b/src/Adapters/SalinitySensor.cpp
@@ -15,9 +15,10 @@ void SalinitySensor::begin() {
     // 2 Step Calibration Code 
     // Serial.println("Starting Salnity Dry Calibration");
     // ec.send_cmd("Cal, dry"); 
+    // delay(600);
     // Serial.println("Finishes, 3 seconds to switch to 80,000");
-    // delay(3000);
-    // ec.send_cmd("Cal, 80000");
+    // delay(5000);
+    // ec.send_cmd("Cal, 12880");
     // delay(600);
     // Serial.println("Salinity Calibration Complete!");
 

--- a/src/Adapters/SalinitySensor.cpp
+++ b/src/Adapters/SalinitySensor.cpp
@@ -10,8 +10,8 @@ void SalinitySensor::begin() {
     bool calibrated, tempComp, kFactor;
     char parsedData[32];
     delay(500);
-    //pinMode(EN_S, OUTPUT);
-    //digitalWrite(EN_S, HIGH);
+    pinMode(EN_S, OUTPUT);
+    digitalWrite(EN_S, HIGH);
     
     ec.send_cmd("Cal,?");
     delay(500);
@@ -104,8 +104,9 @@ bool SalinitySensor::readSalinity(float* salinity) {
     //     EnableDisableSingleReading(SAL, 1);
 
     // }
-    //pinMode(EN_S, OUTPUT);
-    //digitalWrite(EN_S, HIGH);
+    pinMode(EN_S, OUTPUT);
+    digitalWrite(EN_S, HIGH);
+
     delay(1200);
     ec.send_cmd("R");
     delay(600);
@@ -113,6 +114,7 @@ bool SalinitySensor::readSalinity(float* salinity) {
     // Serial.print("RAW salinity Read: ");
     // Serial.println(ec_data);
 
+    digitalWrite(EN_S, LOW);
     if (ec_data[0] != '\0') {
         *salinity = atof(ec_data);
         return true;
@@ -128,7 +130,7 @@ bool SalinitySensor::readTDS(float* salinity){
     EnableDisableSingleReading(SAL, 0);
     EnableDisableSingleReading(TDS, 1);
 
-    //digitalWrite(EN_S, HIGH);
+    digitalWrite(EN_S, HIGH);
     delay(600);
     ec.send_cmd("R");
     delay(600);
@@ -148,7 +150,7 @@ bool SalinitySensor::readEC(float* salinity){
     EnableDisableSingleReading(EC, 0);
     EnableDisableSingleReading(EC, 1);
 
-    //digitalWrite(EN_S, HIGH);
+    digitalWrite(EN_S, HIGH);
     delay(600);
     ec.send_cmd("R");
     delay(600);

--- a/src/Adapters/TempSensor.cpp
+++ b/src/Adapters/TempSensor.cpp
@@ -2,15 +2,17 @@
 
 TempSensor& temp = TempSensor::Get();
 
-
 /**
  * Initializing the sensors instances for temperature and humidity
 **/
 TempSensor::TempSensor():
+    
     dht(DHTPIN,DHTTYPE),
     oneWire(ONE_WIRE_BUS),
     sensors(&oneWire)
+
     {}
+    
 
 TempSensor& TempSensor::Get(){
     static TempSensor instance;
@@ -20,6 +22,13 @@ TempSensor& TempSensor::Get(){
 void TempSensor::begin(){
     dht.begin();
     sensors.begin();
+
+    
+}
+
+bool TempSensor::readTemp(TEMP tempScale, float* temperature)   {
+
+    return true;
 }
 
 bool TempSensor::readHumidity(float* humidity) {
@@ -46,7 +55,7 @@ bool TempSensor::readTemperature(TEMP tempScale, float* temperature) {
     }
 
     sensors.requestTemperatures(); // Request temperature readings
-
+    Serial.println(sensors.requestTemperatures());
     switch (tempScale) {
         case CELSIUS:
             *temperature = sensors.getTempCByIndex(0); // Read temperature in Celsius
@@ -67,4 +76,8 @@ bool TempSensor::readTemperature(TEMP tempScale, float* temperature) {
     }
 
     return true; // Successful read
+}
+
+int TempSensor::findDevices()   {
+    return 0;
 }

--- a/src/Adapters/TurbiditySensor.cpp
+++ b/src/Adapters/TurbiditySensor.cpp
@@ -8,11 +8,13 @@ TurbiditySensor& tbdty = TurbiditySensor::Get();
 TurbiditySensor::TurbiditySensor() {}
 
 void TurbiditySensor::begin() {
+
     EEPROM.get(EEPROM_VCLEAR_ADDRESS, vClear); // Retrieve the vClear from EEPROM
     analogReadResolution(12); // Set ADC resolution to 12-bit
     pinMode(EN, OUTPUT);
-    pinMode(T_ANALOG_PIN, INPUT);  //GPIO1
-    adcAttachPin(1);    //GPIO1
+    wakeup();
+    //pinMode(T_ANALOG_PIN, INPUT);  //GPIO2
+    adcAttachPin(T_ANALOG_PIN);    //GPIO2
     wakeup();
 }
 
@@ -38,7 +40,6 @@ float TurbiditySensor::calibrate() {
 
 bool TurbiditySensor::readTurbidity(float* turbidity) {
     wakeup();
-
     if (turbidity == nullptr) {
         return false; // Invalid pointer
     }

--- a/src/Adapters/TurbiditySensor.cpp
+++ b/src/Adapters/TurbiditySensor.cpp
@@ -1,5 +1,7 @@
 #include "TurbiditySensor.h"
 #include <Arduino.h>
+#include <esp_adc_cal.h>
+#include <esp32-hal-adc.h>
 
 TurbiditySensor& tbdty = TurbiditySensor::Get();
 
@@ -9,6 +11,8 @@ void TurbiditySensor::begin() {
     EEPROM.get(EEPROM_VCLEAR_ADDRESS, vClear); // Retrieve the vClear from EEPROM
     analogReadResolution(12); // Set ADC resolution to 12-bit
     pinMode(EN, OUTPUT);
+    pinMode(T_ANALOG_PIN, INPUT);  //GPIO1
+    adcAttachPin(1);    //GPIO1
     wakeup();
 }
 
@@ -21,6 +25,7 @@ float TurbiditySensor::calibrate() {
     cumulativeRead = 0;
     for (int i = 0; i < READ_SAMPLES; ++i) {
         cumulativeRead += analogRead(T_ANALOG_PIN);
+;
         delay(100); // Delay for stability
     }
     float sensorVoltage = static_cast<float>(cumulativeRead) / READ_SAMPLES * (VREF / ADC_DIGITAL);

--- a/src/Adapters/dallasTemperature.cpp
+++ b/src/Adapters/dallasTemperature.cpp
@@ -1,0 +1,1122 @@
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+#include "DallasTemperature.h"
+
+// for Particle support
+// yield() is not a standard function, but instead wraps Particle process
+// https://community.particle.io/t/syscall-yield-operation/40708/2
+#if defined(PLATFORM_ID)  // Only defined if a Particle device
+inline void yield() {
+	Particle.process();
+}
+#elif ARDUINO >= 100
+#include "Arduino.h"
+#else
+extern "C" {
+#include "WConstants.h"
+}
+#endif
+
+// OneWire commands
+#define STARTCONVO      0x44  // Tells device to take a temperature reading and put it on the scratchpad
+#define COPYSCRATCH     0x48  // Copy scratchpad to EEPROM
+#define READSCRATCH     0xBE  // Read from scratchpad
+#define WRITESCRATCH    0x4E  // Write to scratchpad
+#define RECALLSCRATCH   0xB8  // Recall from EEPROM to scratchpad
+#define READPOWERSUPPLY 0xB4  // Determine if device needs parasite power
+#define ALARMSEARCH     0xEC  // Query bus for devices with an alarm condition
+
+// Scratchpad locations
+#define TEMP_LSB        0
+#define TEMP_MSB        1
+#define HIGH_ALARM_TEMP 2
+#define LOW_ALARM_TEMP  3
+#define CONFIGURATION   4
+#define INTERNAL_BYTE   5
+#define COUNT_REMAIN    6
+#define COUNT_PER_C     7
+#define SCRATCHPAD_CRC  8
+
+// DSROM FIELDS
+#define DSROM_FAMILY    0
+#define DSROM_CRC       7
+
+// Device resolution
+#define TEMP_9_BIT  0x1F //  9 bit
+#define TEMP_10_BIT 0x3F // 10 bit
+#define TEMP_11_BIT 0x5F // 11 bit
+#define TEMP_12_BIT 0x7F // 12 bit
+
+#define MAX_CONVERSION_TIMEOUT		750
+
+// Alarm handler
+#define NO_ALARM_HANDLER ((AlarmHandler *)0)
+
+
+DallasTemperature::DallasTemperature() {
+#if REQUIRESALARMS
+	setAlarmHandler(NO_ALARM_HANDLER);
+#endif
+	useExternalPullup = false;
+}
+
+DallasTemperature::DallasTemperature(OneWire* _oneWire) : DallasTemperature() {
+	setOneWire(_oneWire);
+}
+
+bool DallasTemperature::validFamily(const uint8_t* deviceAddress) {
+	switch (deviceAddress[DSROM_FAMILY]) {
+	case DS18S20MODEL:
+	case DS18B20MODEL:
+	case DS1822MODEL:
+	case DS1825MODEL:
+	case DS28EA00MODEL:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/*
+ * Constructs DallasTemperature with strong pull-up turned on. Strong pull-up is mandated in DS18B20 datasheet for parasitic
+ * power (2 wires) setup. (https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf, p. 7, section 'Powering the DS18B20').
+ */
+DallasTemperature::DallasTemperature(OneWire* _oneWire, uint8_t _pullupPin) : DallasTemperature(_oneWire) {
+	setPullupPin(_pullupPin);
+}
+
+void DallasTemperature::setPullupPin(uint8_t _pullupPin) {
+	useExternalPullup = true;
+	pullupPin = _pullupPin;
+	pinMode(pullupPin, OUTPUT);
+	deactivateExternalPullup();
+}
+
+void DallasTemperature::setOneWire(OneWire* _oneWire) {
+
+	_wire = _oneWire;
+	devices = 0;
+	ds18Count = 0;
+	parasite = false;
+	globalBitResolution = 9;
+	waitForConversion = true;
+	checkForConversion = true;
+	autoSaveScratchPad = true;
+
+}
+
+// initialise the bus
+void DallasTemperature::begin(void) {
+
+	DeviceAddress deviceAddress;
+
+	_wire->reset_search();
+	devices = 0; // Reset the number of devices when we enumerate wire devices
+	ds18Count = 0; // Reset number of DS18xxx Family devices
+
+	while (_wire->search(deviceAddress)) {
+
+		if (validAddress(deviceAddress)) {
+			devices++;
+
+			if (validFamily(deviceAddress)) {
+				ds18Count++;
+
+				if (!parasite && readPowerSupply(deviceAddress))
+					parasite = true;
+
+				uint8_t b = getResolution(deviceAddress);
+				if (b > globalBitResolution) globalBitResolution = b;
+			}
+		}
+	}
+}
+
+// returns the number of devices found on the bus
+uint8_t DallasTemperature::getDeviceCount(void) {
+	return devices;
+}
+
+uint8_t DallasTemperature::getDS18Count(void) {
+	return ds18Count;
+}
+
+// returns true if address is valid
+bool DallasTemperature::validAddress(const uint8_t* deviceAddress) {
+	return (_wire->crc8((uint8_t*)deviceAddress, 7) == deviceAddress[DSROM_CRC]);
+}
+
+// finds an address at a given index on the bus
+// returns true if the device was found
+bool DallasTemperature::getAddress(uint8_t* deviceAddress, uint8_t index) {
+
+	uint8_t depth = 0;
+
+	_wire->reset_search();
+
+	while (depth <= index && _wire->search(deviceAddress)) {
+		if (depth == index && validAddress(deviceAddress))
+			return true;
+		depth++;
+	}
+
+	return false;
+
+}
+
+// attempt to determine if the device at the given address is connected to the bus
+bool DallasTemperature::isConnected(const uint8_t* deviceAddress) {
+
+	ScratchPad scratchPad;
+	return isConnected(deviceAddress, scratchPad);
+
+}
+
+// attempt to determine if the device at the given address is connected to the bus
+// also allows for updating the read scratchpad
+bool DallasTemperature::isConnected(const uint8_t* deviceAddress,
+                                    uint8_t* scratchPad) {
+	bool b = readScratchPad(deviceAddress, scratchPad);
+	return b && !isAllZeros(scratchPad) && (_wire->crc8(scratchPad, 8) == scratchPad[SCRATCHPAD_CRC]);
+}
+
+bool DallasTemperature::readScratchPad(const uint8_t* deviceAddress,
+                                       uint8_t* scratchPad) {
+
+	// send the reset command and fail fast
+	int b = _wire->reset();
+	if (b == 0)
+		return false;
+
+	_wire->select(deviceAddress);
+	_wire->write(READSCRATCH);
+
+	// Read all registers in a simple loop
+	// byte 0: temperature LSB
+	// byte 1: temperature MSB
+	// byte 2: high alarm temp
+	// byte 3: low alarm temp
+	// byte 4: DS18S20: store for crc
+	//         DS18B20 & DS1822: configuration register
+	// byte 5: internal use & crc
+	// byte 6: DS18S20: COUNT_REMAIN
+	//         DS18B20 & DS1822: store for crc
+	// byte 7: DS18S20: COUNT_PER_C
+	//         DS18B20 & DS1822: store for crc
+	// byte 8: SCRATCHPAD_CRC
+	for (uint8_t i = 0; i < 9; i++) {
+		scratchPad[i] = _wire->read();
+	}
+
+	b = _wire->reset();
+	return (b == 1);
+}
+
+void DallasTemperature::writeScratchPad(const uint8_t* deviceAddress,
+                                        const uint8_t* scratchPad) {
+
+	_wire->reset();
+	_wire->select(deviceAddress);
+	_wire->write(WRITESCRATCH);
+	_wire->write(scratchPad[HIGH_ALARM_TEMP]); // high alarm temp
+	_wire->write(scratchPad[LOW_ALARM_TEMP]); // low alarm temp
+
+	// DS1820 and DS18S20 have no configuration register
+	if (deviceAddress[DSROM_FAMILY] != DS18S20MODEL)
+		_wire->write(scratchPad[CONFIGURATION]);
+
+	if (autoSaveScratchPad)
+		saveScratchPad(deviceAddress);
+	else
+		_wire->reset();
+}
+
+// returns true if parasite mode is used (2 wire)
+// returns false if normal mode is used (3 wire)
+// if no address is given (or nullptr) it checks if any device on the bus
+// uses parasite mode.
+// See issue #145
+bool DallasTemperature::readPowerSupply(const uint8_t* deviceAddress)
+{
+	bool parasiteMode = false;
+	_wire->reset();
+	if (deviceAddress == nullptr)
+		_wire->skip();
+	else
+		_wire->select(deviceAddress);
+
+	_wire->write(READPOWERSUPPLY);
+	if (_wire->read_bit() == 0)
+		parasiteMode = true;
+	_wire->reset();
+	return parasiteMode;
+}
+
+// set resolution of all devices to 9, 10, 11, or 12 bits
+// if new resolution is out of range, it is constrained.
+void DallasTemperature::setResolution(uint8_t newResolution) {
+
+	globalBitResolution = constrain(newResolution, 9, 12);
+	DeviceAddress deviceAddress;
+	_wire->reset_search();
+	for (uint8_t i = 0; i < devices; i++) {
+		if(_wire->search(deviceAddress) && validAddress(deviceAddress)) {
+			setResolution(deviceAddress, globalBitResolution, true);
+		}
+	}
+}
+
+/*  PROPOSAL */
+
+// set resolution of a device to 9, 10, 11, or 12 bits
+// if new resolution is out of range, 9 bits is used.
+bool DallasTemperature::setResolution(const uint8_t* deviceAddress,
+                                      uint8_t newResolution, bool skipGlobalBitResolutionCalculation) {
+
+	bool success = false;
+
+	// DS1820 and DS18S20 have no resolution configuration register
+	if (deviceAddress[DSROM_FAMILY] == DS18S20MODEL) {
+		success = true;
+	} else {
+
+		// handle the sensors with configuration register
+		newResolution = constrain(newResolution, 9, 12);
+		uint8_t newValue = 0;
+		ScratchPad scratchPad;
+
+		// we can only update the sensor if it is connected
+		if (isConnected(deviceAddress, scratchPad)) {
+			// MAX31850 has no resolution configuration register
+			// this is also a hack as the MAX31850 Coversion time is 100ms max.
+			// use a low res (~10 by spec, but 9 might work) for faster blocking read times.
+			if (deviceAddress[DSROM_FAMILY] == DS1825MODEL && scratchPad[CONFIGURATION] & 0x80 ) {
+				success = true;
+			} else {
+				switch (newResolution) {
+				case 12:
+					newValue = TEMP_12_BIT;
+					break;
+				case 11:
+					newValue = TEMP_11_BIT;
+					break;
+				case 10:
+					newValue = TEMP_10_BIT;
+					break;
+				case 9:
+				default:
+					newValue = TEMP_9_BIT;
+					break;
+				}
+
+				// if it needs to be updated we write the new value
+				if (scratchPad[CONFIGURATION] != newValue) {
+					scratchPad[CONFIGURATION] = newValue;
+					writeScratchPad(deviceAddress, scratchPad);
+				}
+				// done
+				success = true;
+			}
+		}
+	}
+
+	// do we need to update the max resolution used?
+	if (skipGlobalBitResolutionCalculation == false) {
+		globalBitResolution = newResolution;
+		if (devices > 1) {
+			DeviceAddress deviceAddr;
+			_wire->reset_search();
+			for (uint8_t i = 0; i < devices; i++) {
+				if (globalBitResolution == 12) break;
+				if (_wire->search(deviceAddr) && validAddress(deviceAddr)) {
+					uint8_t b = getResolution(deviceAddr);
+					if (b > globalBitResolution) globalBitResolution = b;
+				}
+			}
+		}
+	}
+
+	return success;
+}
+
+
+// returns the global resolution
+uint8_t DallasTemperature::getResolution() {
+	return globalBitResolution;
+}
+
+// returns the current resolution of the device, 9-12
+// returns 0 if device not found
+uint8_t DallasTemperature::getResolution(const uint8_t* deviceAddress) {
+
+	// DS1820 and DS18S20 have no resolution configuration register
+	if (deviceAddress[DSROM_FAMILY] == DS18S20MODEL)
+		return 12;
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad)) {
+
+		// MAX31850 has no resolution configuration register
+		if (deviceAddress[DSROM_FAMILY] == DS1825MODEL && scratchPad[CONFIGURATION] & 0x80)
+			return 12;
+
+		switch (scratchPad[CONFIGURATION]) {
+		case TEMP_12_BIT:
+			return 12;
+
+		case TEMP_11_BIT:
+			return 11;
+
+		case TEMP_10_BIT:
+			return 10;
+
+		case TEMP_9_BIT:
+			return 9;
+		}
+	}
+	return 0;
+
+}
+
+
+// sets the value of the waitForConversion flag
+// TRUE : function requestTemperature() etc returns when conversion is ready
+// FALSE: function requestTemperature() etc returns immediately (USE WITH CARE!!)
+//        (1) programmer has to check if the needed delay has passed
+//        (2) but the application can do meaningful things in that time
+void DallasTemperature::setWaitForConversion(bool flag) {
+	waitForConversion = flag;
+}
+
+// gets the value of the waitForConversion flag
+bool DallasTemperature::getWaitForConversion() {
+	return waitForConversion;
+}
+
+// sets the value of the checkForConversion flag
+// TRUE : function requestTemperature() etc will 'listen' to an IC to determine whether a conversion is complete
+// FALSE: function requestTemperature() etc will wait a set time (worst case scenario) for a conversion to complete
+void DallasTemperature::setCheckForConversion(bool flag) {
+	checkForConversion = flag;
+}
+
+// gets the value of the waitForConversion flag
+bool DallasTemperature::getCheckForConversion() {
+	return checkForConversion;
+}
+
+bool DallasTemperature::isConversionComplete() {
+	uint8_t b = _wire->read_bit();
+	return (b == 1);
+}
+
+// sends command for all devices on the bus to perform a temperature conversion
+DallasTemperature::request_t DallasTemperature::requestTemperatures() {
+	DallasTemperature::request_t req = {};
+	req.result = true;
+
+	_wire->reset();
+	_wire->skip();
+	_wire->write(STARTCONVO, parasite);
+
+	// ASYNC mode?
+	req.timestamp = millis();
+	if (!waitForConversion)
+		return req;
+	blockTillConversionComplete(globalBitResolution, req.timestamp);
+	return req;
+}
+
+// sends command for one device to perform a temperature by address
+// returns FALSE if device is disconnected
+// returns TRUE  otherwise
+DallasTemperature::request_t DallasTemperature::requestTemperaturesByAddress(const uint8_t* deviceAddress) {
+	DallasTemperature::request_t req = {};
+	uint8_t deviceBitResolution = getResolution(deviceAddress);
+	if (deviceBitResolution == 0) {
+		req.result = false;
+		return req; //Device disconnected
+	}
+
+	_wire->reset();
+	_wire->select(deviceAddress);
+	_wire->write(STARTCONVO, parasite);
+
+	req.timestamp = millis();
+	// ASYNC mode?
+	req.result = true;
+	if (!waitForConversion)
+		return req;
+
+	blockTillConversionComplete(deviceBitResolution, req.timestamp);
+
+	return req;
+
+}
+
+// Continue to check if the IC has responded with a temperature
+void DallasTemperature::blockTillConversionComplete(uint8_t bitResolution, unsigned long start) {
+	if (checkForConversion && !parasite) {
+		while (!isConversionComplete() && (millis() - start <  MAX_CONVERSION_TIMEOUT))
+			yield();
+	} else {
+		unsigned long delms = millisToWaitForConversion(bitResolution);
+		activateExternalPullup();
+		delay(delms);
+		deactivateExternalPullup();
+	}
+
+}
+
+// Continue to check if the IC has responded with a temperature
+void DallasTemperature::blockTillConversionComplete(uint8_t bitResolution) {
+	unsigned long start = millis();
+	blockTillConversionComplete(bitResolution, start);
+}
+
+// Continue to check if the IC has responded with a temperature
+void DallasTemperature::blockTillConversionComplete(uint8_t bitResolution, DallasTemperature::request_t req) {
+	if (req.result)
+		blockTillConversionComplete(bitResolution, req.timestamp);
+}
+
+// returns number of milliseconds to wait till conversion is complete (based on IC datasheet)
+uint16_t DallasTemperature::millisToWaitForConversion(uint8_t bitResolution) {
+
+	switch (bitResolution) {
+	case 9:
+		return 94;
+	case 10:
+		return 188;
+	case 11:
+		return 375;
+	default:
+		return 750;
+	}
+
+}
+
+// returns number of milliseconds to wait till conversion is complete (based on IC datasheet)
+uint16_t DallasTemperature::millisToWaitForConversion() {
+	return millisToWaitForConversion(globalBitResolution);
+}
+
+// Sends command to one device to save values from scratchpad to EEPROM by index
+// Returns true if no errors were encountered, false indicates failure
+bool DallasTemperature::saveScratchPadByIndex(uint8_t deviceIndex) {
+
+	DeviceAddress deviceAddress;
+	if (!getAddress(deviceAddress, deviceIndex)) return false;
+
+	return saveScratchPad(deviceAddress);
+
+}
+
+// Sends command to one or more devices to save values from scratchpad to EEPROM
+// If optional argument deviceAddress is omitted the command is send to all devices
+// Returns true if no errors were encountered, false indicates failure
+bool DallasTemperature::saveScratchPad(const uint8_t* deviceAddress) {
+
+	if (_wire->reset() == 0)
+		return false;
+
+	if (deviceAddress == nullptr)
+		_wire->skip();
+	else
+		_wire->select(deviceAddress);
+
+	_wire->write(COPYSCRATCH, parasite);
+
+	// Specification: NV Write Cycle Time is typically 2ms, max 10ms
+	// Waiting 20ms to allow for sensors that take longer in practice
+	if (!parasite) {
+		delay(20);
+	} else {
+		activateExternalPullup();
+		delay(20);
+		deactivateExternalPullup();
+	}
+
+	return _wire->reset() == 1;
+
+}
+
+// Sends command to one device to recall values from EEPROM to scratchpad by index
+// Returns true if no errors were encountered, false indicates failure
+bool DallasTemperature::recallScratchPadByIndex(uint8_t deviceIndex) {
+
+	DeviceAddress deviceAddress;
+	if (!getAddress(deviceAddress, deviceIndex)) return false;
+
+	return recallScratchPad(deviceAddress);
+
+}
+
+// Sends command to one or more devices to recall values from EEPROM to scratchpad
+// If optional argument deviceAddress is omitted the command is send to all devices
+// Returns true if no errors were encountered, false indicates failure
+bool DallasTemperature::recallScratchPad(const uint8_t* deviceAddress) {
+
+	if (_wire->reset() == 0)
+		return false;
+
+	if (deviceAddress == nullptr)
+		_wire->skip();
+	else
+		_wire->select(deviceAddress);
+
+	_wire->write(RECALLSCRATCH, parasite);
+
+	// Specification: Strong pullup only needed when writing to EEPROM (and temp conversion)
+	unsigned long start = millis();
+	while (_wire->read_bit() == 0) {
+		// Datasheet doesn't specify typical/max duration, testing reveals typically within 1ms
+		if (millis() - start > 20) return false;
+		yield();
+	}
+
+	return _wire->reset() == 1;
+
+}
+
+// Sets the autoSaveScratchPad flag
+void DallasTemperature::setAutoSaveScratchPad(bool flag) {
+	autoSaveScratchPad = flag;
+}
+
+// Gets the autoSaveScratchPad flag
+bool DallasTemperature::getAutoSaveScratchPad() {
+	return autoSaveScratchPad;
+}
+
+void DallasTemperature::activateExternalPullup() {
+	if (useExternalPullup)
+		digitalWrite(pullupPin, LOW);
+}
+
+void DallasTemperature::deactivateExternalPullup() {
+	if (useExternalPullup)
+		digitalWrite(pullupPin, HIGH);
+}
+
+// sends command for one device to perform a temp conversion by index
+DallasTemperature::request_t DallasTemperature::requestTemperaturesByIndex(uint8_t deviceIndex) {
+
+	DeviceAddress deviceAddress;
+	getAddress(deviceAddress, deviceIndex);
+
+	return requestTemperaturesByAddress(deviceAddress);
+
+}
+
+// Fetch temperature for device index
+float DallasTemperature::getTempCByIndex(uint8_t deviceIndex) {
+
+	DeviceAddress deviceAddress;
+	if (!getAddress(deviceAddress, deviceIndex)) {
+		return DEVICE_DISCONNECTED_C;
+	}
+	return getTempC((uint8_t*) deviceAddress);
+}
+
+// Fetch temperature for device index
+float DallasTemperature::getTempFByIndex(uint8_t deviceIndex) {
+
+	DeviceAddress deviceAddress;
+
+	if (!getAddress(deviceAddress, deviceIndex)) {
+		return DEVICE_DISCONNECTED_F;
+	}
+
+	return getTempF((uint8_t*) deviceAddress);
+
+}
+
+// reads scratchpad and returns fixed-point temperature, scaling factor 2^-7
+int32_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress,
+                                                uint8_t* scratchPad) {
+
+	int32_t fpTemperature = 0;
+
+	// looking thru the spec sheets of all supported devices, bit 15 is always the signing bit
+	// Detected if signed
+	int32_t neg = 0x0;
+	if (scratchPad[TEMP_MSB] & 0x80)
+		neg = 0xFFF80000;
+
+	// detect MAX31850
+	// The temp range on a MAX31850 can far exceed other models, causing an overrun @ 256C
+	// Based on the spec sheets for the MAX31850, bit 7 is always 1
+	// Whereas the DS1825 bit 7 is always 0
+	// DS1825   - https://datasheets.maximintegrated.com/en/ds/DS1825.pdf
+	// MAX31850 - https://datasheets.maximintegrated.com/en/ds/MAX31850-MAX31851.pdf
+
+	if (deviceAddress[DSROM_FAMILY] == DS1825MODEL && scratchPad[CONFIGURATION] & 0x80 ) {
+		//Serial.print("  Detected MAX31850");
+		if (scratchPad[TEMP_LSB] & 1) { // Fault Detected
+			if (scratchPad[HIGH_ALARM_TEMP] & 1) {
+				//Serial.println("open detected");
+				return DEVICE_FAULT_OPEN_RAW;
+			}
+			else if (scratchPad[HIGH_ALARM_TEMP] >> 1 & 1) {
+				//Serial.println("short to ground detected");
+				return DEVICE_FAULT_SHORTGND_RAW;
+			}
+			else if (scratchPad[HIGH_ALARM_TEMP] >> 2 & 1) {
+				//Serial.println("short to Vdd detected");
+				return DEVICE_FAULT_SHORTVDD_RAW;
+			}
+			else {
+				// We don't know why there's a fault, exit with disconnect value
+				return DEVICE_DISCONNECTED_RAW;
+			}
+		}
+		// We must mask out bit 1 (reserved) and 0 (fault) on TEMP_LSB
+		fpTemperature = (((int32_t) scratchPad[TEMP_MSB]) << 11)
+		                | (((int32_t) scratchPad[TEMP_LSB] & 0xFC) << 3)
+		                | neg;
+	} else {
+		fpTemperature = (((int16_t) scratchPad[TEMP_MSB]) << 11)
+		                | (((int16_t) scratchPad[TEMP_LSB]) << 3)
+		                | neg;
+	}
+
+	/*
+	 DS1820 and DS18S20 have a 9-bit temperature register.
+
+	 Resolutions greater than 9-bit can be calculated using the data from
+	 the temperature, and COUNT REMAIN and COUNT PER °C registers in the
+	 scratchpad.  The resolution of the calculation depends on the model.
+
+	 While the COUNT PER °C register is hard-wired to 16 (10h) in a
+	 DS18S20, it changes with temperature in DS1820.
+
+	 After reading the scratchpad, the TEMP_READ value is obtained by
+	 truncating the 0.5°C bit (bit 0) from the temperature data. The
+	 extended resolution temperature can then be calculated using the
+	 following equation:
+
+	                                  COUNT_PER_C - COUNT_REMAIN
+	 TEMPERATURE = TEMP_READ - 0.25 + --------------------------
+	                                         COUNT_PER_C
+
+	 Hagai Shatz simplified this to integer arithmetic for a 12 bits
+	 value for a DS18S20, and James Cameron added legacy DS1820 support.
+
+	 See - http://myarduinotoy.blogspot.co.uk/2013/02/12bit-result-from-ds18s20.html
+	 */
+
+	if ((deviceAddress[DSROM_FAMILY] == DS18S20MODEL) && (scratchPad[COUNT_PER_C] != 0)) {
+		fpTemperature = (((fpTemperature & 0xfff0) << 3) - 32
+		                + (((scratchPad[COUNT_PER_C] - scratchPad[COUNT_REMAIN]) << 7)
+		                   / scratchPad[COUNT_PER_C])) | neg;
+	}
+
+	return fpTemperature;
+}
+
+// returns temperature in 1/128 degrees C or DEVICE_DISCONNECTED_RAW if the
+// device's scratch pad cannot be read successfully.
+// the numeric value of DEVICE_DISCONNECTED_RAW is defined in
+// DallasTemperature.h. It is a large negative number outside the
+// operating range of the device
+int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress) {
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad))
+		return calculateTemperature(deviceAddress, scratchPad);
+	return DEVICE_DISCONNECTED_RAW;
+
+}
+
+// returns temperature in degrees C or DEVICE_DISCONNECTED_C if the
+// device's scratch pad cannot be read successfully.
+// the numeric value of DEVICE_DISCONNECTED_C is defined in
+// DallasTemperature.h. It is a large negative number outside the
+// operating range of the device
+float DallasTemperature::getTempC(const uint8_t* deviceAddress) {
+	return rawToCelsius(getTemp(deviceAddress));
+}
+
+// returns temperature in degrees F or DEVICE_DISCONNECTED_F if the
+// device's scratch pad cannot be read successfully.
+// the numeric value of DEVICE_DISCONNECTED_F is defined in
+// DallasTemperature.h. It is a large negative number outside the
+// operating range of the device
+float DallasTemperature::getTempF(const uint8_t* deviceAddress) {
+	return rawToFahrenheit(getTemp(deviceAddress));
+}
+
+// returns true if the bus requires parasite power
+bool DallasTemperature::isParasitePowerMode(void) {
+	return parasite;
+}
+
+// IF alarm is not used one can store a 16 bit int of userdata in the alarm
+// registers. E.g. an ID of the sensor.
+// See github issue #29
+
+// note if device is not connected it will fail writing the data.
+void DallasTemperature::setUserData(const uint8_t* deviceAddress,
+                                    int16_t data) {
+	// return when stored value == new value
+	if (getUserData(deviceAddress) == data)
+		return;
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad)) {
+		scratchPad[HIGH_ALARM_TEMP] = data >> 8;
+		scratchPad[LOW_ALARM_TEMP] = data & 255;
+		writeScratchPad(deviceAddress, scratchPad);
+	}
+}
+
+int16_t DallasTemperature::getUserData(const uint8_t* deviceAddress) {
+	int16_t data = 0;
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad)) {
+		data = scratchPad[HIGH_ALARM_TEMP] << 8;
+		data += scratchPad[LOW_ALARM_TEMP];
+	}
+	return data;
+}
+
+// note If address cannot be found no error will be reported.
+int16_t DallasTemperature::getUserDataByIndex(uint8_t deviceIndex) {
+	DeviceAddress deviceAddress;
+	getAddress(deviceAddress, deviceIndex);
+	return getUserData((uint8_t*) deviceAddress);
+}
+
+void DallasTemperature::setUserDataByIndex(uint8_t deviceIndex, int16_t data) {
+	DeviceAddress deviceAddress;
+	getAddress(deviceAddress, deviceIndex);
+	setUserData((uint8_t*) deviceAddress, data);
+}
+
+// Convert float Celsius to Fahrenheit
+float DallasTemperature::toFahrenheit(float celsius) {
+	return (celsius * 1.8f) + 32.0f;
+}
+
+// Convert float Fahrenheit to Celsius
+float DallasTemperature::toCelsius(float fahrenheit) {
+	return (fahrenheit - 32.0f) * 0.555555556f;
+}
+
+// convert from raw to Celsius
+float DallasTemperature::rawToCelsius(int32_t raw) {
+
+	if (raw <= DEVICE_DISCONNECTED_RAW)
+		return DEVICE_DISCONNECTED_C;
+	// C = RAW/128
+	return (float) raw * 0.0078125f;
+
+}
+
+// Convert from Celsius to raw returns temperature in raw integer format.
+// The rounding error in the conversion is smaller than 0.01°C
+// where the resolution of the sensor is at best 0.0625°C (in 12 bit mode).
+// Rounding error can be verified by running:
+//  for (float t=-55.; t<125.; t+=0.01)
+//  {
+//    Serial.println( DallasTemperature::rawToCelsius(DallasTemperature::celsiusToRaw(t))-t, 4 );
+//  }
+int16_t DallasTemperature::celsiusToRaw(float celsius) {
+
+	return static_cast<uint16_t>( celsius * 128.f );
+}
+
+// convert from raw to Fahrenheit
+float DallasTemperature::rawToFahrenheit(int32_t raw) {
+
+	if (raw <= DEVICE_DISCONNECTED_RAW)
+		return DEVICE_DISCONNECTED_F;
+	// C = RAW/128
+	// F = (C*1.8)+32 = (RAW/128*1.8)+32 = (RAW*0.0140625)+32
+	return ((float) raw * 0.0140625f) + 32.0f;
+
+}
+
+// Returns true if all bytes of scratchPad are '\0'
+bool DallasTemperature::isAllZeros(const uint8_t * const scratchPad, const size_t length) {
+	for (size_t i = 0; i < length; i++) {
+		if (scratchPad[i] != 0) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+#if REQUIRESALARMS
+
+/*
+
+ ALARMS:
+
+ TH and TL Register Format
+
+ BIT 7 BIT 6 BIT 5 BIT 4 BIT 3 BIT 2 BIT 1 BIT 0
+ S    2^6   2^5   2^4   2^3   2^2   2^1   2^0
+
+ Only bits 11 through 4 of the temperature register are used
+ in the TH and TL comparison since TH and TL are 8-bit
+ registers. If the measured temperature is lower than or equal
+ to TL or higher than or equal to TH, an alarm condition exists
+ and an alarm flag is set inside the DS18B20. This flag is
+ updated after every temperature measurement; therefore, if the
+ alarm condition goes away, the flag will be turned off after
+ the next temperature conversion.
+
+ */
+
+// sets the high alarm temperature for a device in degrees Celsius
+// accepts a float, but the alarm resolution will ignore anything
+// after a decimal point.  valid range is -55C - 125C
+void DallasTemperature::setHighAlarmTemp(const uint8_t* deviceAddress,
+                                         int8_t celsius) {
+
+	// return when stored value == new value
+	if (getHighAlarmTemp(deviceAddress) == celsius)
+		return;
+
+	// make sure the alarm temperature is within the device's range
+	if (celsius > 125)
+		celsius = 125;
+	else if (celsius < -55)
+		celsius = -55;
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad)) {
+		scratchPad[HIGH_ALARM_TEMP] = (uint8_t) celsius;
+		writeScratchPad(deviceAddress, scratchPad);
+	}
+
+}
+
+// sets the low alarm temperature for a device in degrees Celsius
+// accepts a float, but the alarm resolution will ignore anything
+// after a decimal point.  valid range is -55C - 125C
+void DallasTemperature::setLowAlarmTemp(const uint8_t* deviceAddress,
+                                        int8_t celsius) {
+
+	// return when stored value == new value
+	if (getLowAlarmTemp(deviceAddress) == celsius)
+		return;
+
+	// make sure the alarm temperature is within the device's range
+	if (celsius > 125)
+		celsius = 125;
+	else if (celsius < -55)
+		celsius = -55;
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad)) {
+		scratchPad[LOW_ALARM_TEMP] = (uint8_t) celsius;
+		writeScratchPad(deviceAddress, scratchPad);
+	}
+
+}
+
+// returns a int8_t with the current high alarm temperature or
+// DEVICE_DISCONNECTED for an address
+int8_t DallasTemperature::getHighAlarmTemp(const uint8_t* deviceAddress) {
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad))
+		return (int8_t) scratchPad[HIGH_ALARM_TEMP];
+	return DEVICE_DISCONNECTED_C;
+
+}
+
+// returns a int8_t with the current low alarm temperature or
+// DEVICE_DISCONNECTED for an address
+int8_t DallasTemperature::getLowAlarmTemp(const uint8_t* deviceAddress) {
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad))
+		return (int8_t) scratchPad[LOW_ALARM_TEMP];
+	return DEVICE_DISCONNECTED_C;
+
+}
+
+// resets internal variables used for the alarm search
+void DallasTemperature::resetAlarmSearch() {
+
+	alarmSearchJunction = -1;
+	alarmSearchExhausted = 0;
+	for (uint8_t i = 0; i < 7; i++) {
+		alarmSearchAddress[i] = 0;
+	}
+
+}
+
+// This is a modified version of the OneWire::search method.
+//
+// Also added the OneWire search fix documented here:
+// http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295
+//
+// Perform an alarm search. If this function returns a '1' then it has
+// enumerated the next device and you may retrieve the ROM from the
+// OneWire::address variable. If there are no devices, no further
+// devices, or something horrible happens in the middle of the
+// enumeration then a 0 is returned.  If a new device is found then
+// its address is copied to newAddr.  Use
+// DallasTemperature::resetAlarmSearch() to start over.
+bool DallasTemperature::alarmSearch(uint8_t* newAddr) {
+
+	uint8_t i;
+	int8_t lastJunction = -1;
+	uint8_t done = 1;
+
+	if (alarmSearchExhausted)
+		return false;
+	if (!_wire->reset())
+		return false;
+
+	// send the alarm search command
+	_wire->write(0xEC, 0);
+
+	for (i = 0; i < 64; i++) {
+
+		uint8_t a = _wire->read_bit();
+		uint8_t nota = _wire->read_bit();
+		uint8_t ibyte = i / 8;
+		uint8_t ibit = 1 << (i & 7);
+
+		// I don't think this should happen, this means nothing responded, but maybe if
+		// something vanishes during the search it will come up.
+		if (a && nota)
+			return false;
+
+		if (!a && !nota) {
+			if (i == alarmSearchJunction) {
+				// this is our time to decide differently, we went zero last time, go one.
+				a = 1;
+				alarmSearchJunction = lastJunction;
+			} else if (i < alarmSearchJunction) {
+
+				// take whatever we took last time, look in address
+				if (alarmSearchAddress[ibyte] & ibit) {
+					a = 1;
+				} else {
+					// Only 0s count as pending junctions, we've already exhausted the 0 side of 1s
+					a = 0;
+					done = 0;
+					lastJunction = i;
+				}
+			} else {
+				// we are blazing new tree, take the 0
+				a = 0;
+				alarmSearchJunction = i;
+				done = 0;
+			}
+			// OneWire search fix
+			// See: http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295
+		}
+
+		if (a)
+			alarmSearchAddress[ibyte] |= ibit;
+		else
+			alarmSearchAddress[ibyte] &= ~ibit;
+
+		_wire->write_bit(a);
+	}
+
+	if (done)
+		alarmSearchExhausted = 1;
+	for (i = 0; i < 8; i++)
+		newAddr[i] = alarmSearchAddress[i];
+	return true;
+
+}
+
+// returns true if device address might have an alarm condition
+// (only an alarm search can verify this)
+bool DallasTemperature::hasAlarm(const uint8_t* deviceAddress) {
+
+	ScratchPad scratchPad;
+	if (isConnected(deviceAddress, scratchPad)) {
+
+		int8_t temp = calculateTemperature(deviceAddress, scratchPad) >> 7;
+
+		// check low alarm
+		if (temp <= (int8_t) scratchPad[LOW_ALARM_TEMP])
+			return true;
+
+		// check high alarm
+		if (temp >= (int8_t) scratchPad[HIGH_ALARM_TEMP])
+			return true;
+	}
+
+	// no alarm
+	return false;
+
+}
+
+// returns true if any device is reporting an alarm condition on the bus
+bool DallasTemperature::hasAlarm(void) {
+
+	DeviceAddress deviceAddress;
+	resetAlarmSearch();
+	return alarmSearch(deviceAddress);
+}
+
+// runs the alarm handler for all devices returned by alarmSearch()
+// unless there no _AlarmHandler exist.
+void DallasTemperature::processAlarms(void) {
+
+	if (!hasAlarmHandler()) {
+		return;
+	}
+
+	resetAlarmSearch();
+	DeviceAddress alarmAddr;
+
+	while (alarmSearch(alarmAddr)) {
+		if (validAddress(alarmAddr)) {
+			_AlarmHandler(alarmAddr);
+		}
+	}
+}
+
+// sets the alarm handler
+void DallasTemperature::setAlarmHandler(const AlarmHandler *handler) {
+	_AlarmHandler = handler;
+}
+
+// checks if AlarmHandler has been set.
+bool DallasTemperature::hasAlarmHandler()
+{
+	return _AlarmHandler != NO_ALARM_HANDLER;
+}
+
+#endif
+
+#if REQUIRESNEW
+
+// MnetCS - Allocates memory for DallasTemperature. Allows us to instance a new object
+void* DallasTemperature::operator new(unsigned int size) { // Implicit NSS obj size
+
+	void * p;// void pointer
+	p = malloc(size);// Allocate memory
+	memset((DallasTemperature*)p, 0, size); // Initialise memory
+
+	//!!! CANT EXPLICITLY CALL CONSTRUCTOR - workaround by using an init() methodR - workaround by using an init() method
+	return (DallasTemperature*) p;// Cast blank region to NSS pointer
+}
+
+// MnetCS 2009 -  Free the memory used by this instance
+void DallasTemperature::operator delete(void* p) {
+
+	DallasTemperature* pNss = (DallasTemperature*) p; // Cast to NSS pointer
+	pNss->~DallasTemperature();// Destruct the object
+
+	free(p);// Free the memory
+}
+
+#endif

--- a/src/Adapters/io_handler.cpp
+++ b/src/Adapters/io_handler.cpp
@@ -37,6 +37,7 @@ void readSensorData(SensorData &data)
     data.turbidityValid = tbdty.readTurbidity(&data.turbidity);
     data.salinityValid = sal.readSalinity(&data.salinity);
     data.tdsValid = sal.readTDS(&data.tds);
+    data.ecValid = sal.readEC(&data.ec);
     data.pHValid = phGloabl.readpH(&data.pH);
     data.oxygenLevelValid = DO.readDO(&data.oxygenLevel, data.salinity, data.temperature);
     data.humidityValid = temp.readHumidity(&data.humidity);
@@ -50,6 +51,7 @@ void readSensorData(SensorData &data)
     data.pH = round(data.pH * 1000.0) / 1000.0;
     data.oxygenLevel = round(data.oxygenLevel * 1000.0) / 1000.0;
     data.tds = round(data.tds * 1000.0) / 1000.0;
+    data.ec = round(data.ec*1000.0) / 1000.0; 
     data.humidity = round(data.humidity * 1000.0) / 1000.0;
 
     Serial.println("Sensor readings complete.");
@@ -92,6 +94,8 @@ void printDataOnCLI(const SensorData& data){
     toPrint += "+-----------------------+-----------------------+\n";
     toPrint+= "|TDS: "+String(data.tds,3)+"\n";
     toPrint += "+-----------------------+-----------------------+\n";
+    toPrint+= "|EC: "+String(data.ec,3)+"\n";
+    toPrint += "+-----------------------+-----------------------+\n";
     toPrint+= "|Oxigen Level: "+String(data.oxygenLevel,3)+"\n";
     toPrint += "+-----------------------+-----------------------+\n";
     toPrint+= "|PH: "+String(data.pH,3)+"\n";
@@ -108,6 +112,7 @@ void validateSensorReadings(SensorData& data) {
     data.turbidityValid = !isnan(data.turbidity) && data.turbidity >= 0;
     data.salinityValid = !isnan(data.salinity) && data.salinity >= 0;
     data.tdsValid = !isnan(data.tds) && data.tds >= 0;
+    data.ecValid = !isnan(data.ec) && data.ec >= 0;
     data.pHValid = !isnan(data.pH) && data.pH >= 0;
     data.oxygenLevelValid = !isnan(data.oxygenLevel) && data.oxygenLevel >= 0;
 }
@@ -139,10 +144,13 @@ String prepareCSVPayload(const SensorData& data)    {
     const tm& timeinfo = get_current_time();
     return String(data.humidity, 3) + ", " + String(data.temperature, 3) +
         ", " + String(data.turbidity, 3) + ", " + String(data.salinity, 3) + 
-        ", " + String(data.tds, 3) + ", " + String(data.pH, 3) + ", " +
-        String(data.oxygenLevel, 3) + ", " + (timeinfo.tm_mon+1) + ", " +
-        timeinfo.tm_mday + ", " + (timeinfo.tm_year) + ", " + timeinfo.tm_hour +
-        ":" + timeinfo.tm_min + ":" + timeinfo.tm_sec;   
+        ", " + String(data.tds, 3) + ", " + String(data.ec, 3) + ", "
+        ", " + String(data.pH, 3) + ", " +
+        String(data.oxygenLevel, 3) + ", " + 
+        (timeinfo.tm_mon+1) + ", " +
+        timeinfo.tm_mday + ", " + 
+        (timeinfo.tm_year) + ", " + 
+        timeinfo.tm_hour + ":" + timeinfo.tm_min + ":" + timeinfo.tm_sec;   
 }
 
 bool saveCSVData(SdFat32 &SD, const String& data) {

--- a/src/Adapters/io_handler.cpp
+++ b/src/Adapters/io_handler.cpp
@@ -42,7 +42,35 @@ void readSensorData(SensorData &data)
     data.oxygenLevelValid = DO.readDO(&data.oxygenLevel, data.salinity, data.temperature);
     data.humidityValid = temp.readHumidity(&data.humidity);
 
-
+    // byte error, address;
+    // int nDevices;
+    // Serial.println("Scanning...");
+    // nDevices = 0;
+    // for(address = 1; address < 127; address++ ) {
+    //     Wire.beginTransmission(address);
+    //     error = Wire.endTransmission();
+    //     if (error == 0) {
+    //     Serial.print("I2C device found at address 0x");
+    //     if (address<16) {
+    //         Serial.print("0");
+    //     }
+    //     Serial.println(address,HEX);
+    //     nDevices++;
+    //     }
+    //     else if (error==4) {
+    //     Serial.print("Unknow error at address 0x");
+    //     if (address<16) {
+    //         Serial.print("0");
+    //     }
+    //     Serial.println(address,HEX);
+    //     }    
+    // }
+    // if (nDevices == 0) {
+    //     Serial.println("No I2C devices found\n");
+    // }
+    // else {
+    //     Serial.println("done\n");
+    // }
 
     // Round readings
     data.temperature = round(data.temperature * 1000.0) / 1000.0;

--- a/src/Adapters/io_handler.cpp
+++ b/src/Adapters/io_handler.cpp
@@ -243,25 +243,25 @@ bool saveJsonData(fs::FS &fs, const String &data) {
             fs.mkdir(directoryPath);
         }
         
+        File file;
         String filename;
         if (!getLocalTime(&timeinfo)) {
             Serial.println("Failed to get local time.");
-            filename = String(directoryPath) + "/unknown-time.json";
-        }else
+            Serial.println("Data will not be saving in JSON format.");
+        }else   {
             filename = String(directoryPath) + "/" + (timeinfo.tm_mon + 1) + '-' + timeinfo.tm_mday + '-' + (timeinfo.tm_year) + "-data.json";
-    
-        //file = SD.open(filename, O_WRITE | O_CREAT | O_APPEND);
-        File file;
-        if (!(file = fs.open(filename, FILE_APPEND))) {
-                Serial.println("Failed to open JSON file for writing.");
-                file = fs.open(filename, FILE_WRITE);
+            if (!(file = fs.open(filename, FILE_APPEND))) {
+                    Serial.println("Failed to open JSON file for writing.");
+                    file = fs.open(filename, FILE_WRITE);
+            }
+            if (file.println(data)) {
+                Serial.println("Data saved successfully.");
+            } else {
+                Serial.println("Failed to save data.");
+                Serial.println(file.println());
+            }
         }
-        if (file.println(data)) {
-            Serial.println("Data saved successfully.");
-        } else {
-            Serial.println("Failed to save data.");
-            Serial.println(file.println());
-        }
+        
         root.close();
         file.close();
         xSemaphoreGive(sdCardMutex);

--- a/src/Adapters/pHSensor.cpp
+++ b/src/Adapters/pHSensor.cpp
@@ -7,6 +7,7 @@ pHSensor::pHSensor() {};
 void pHSensor::begin()  {
     pH.begin();
     pinMode(EN, OUTPUT);
+    digitalWrite(EN, HIGH);
     wakeup();
 }
 

--- a/src/ioExtender.cpp
+++ b/src/ioExtender.cpp
@@ -1,0 +1,30 @@
+#include <ioExtender.h>
+
+MCP& mcpGlobal = MCP::Get();
+
+MCP::MCP() {};
+
+void MCP::begin()   {
+    if(!mcp.begin_I2C(0x20))    {
+        Serial.println("Error, MCP did not connect to I2C");
+    }else
+        Serial.println("I2C MCP connected!");
+}
+
+void MCP::pinMode(int pin, uint8_t mode)    {
+    mcp.pinMode(pin, mode);
+}
+
+void MCP::digitalWrite(uint8_t pin, uint8_t value)  {
+    mcp.digitalWrite(pin, value);
+}
+
+uint8_t MCP::digitalRead(uint8_t pin)    {
+    return mcp.digitalRead(pin);
+}
+
+MCP& MCP::Get() {
+    static MCP instance;
+    return instance;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ void setup() {
     tbdty.begin();
     phGloabl.begin();
     DO.begin();
-    sal.begin(); //also tds
+    sal.begin(); //also tds & ec
 
     // Create mutexes
     sdCardMutex = xSemaphoreCreateMutex();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,8 +341,8 @@ void stopSensorTask() {
     }
     digitalWrite(25, LOW);
     digitalWrite(26, LOW);
-    gpio_hold_en(GPIO_NUM_25);
-    gpio_hold_en(GPIO_NUM_26);
+    //gpio_hold_en(GPIO_NUM_25);
+    //gpio_hold_en(GPIO_NUM_26);
 }
 
 void readBatteryTask(void *pvParameters) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "soc/rtc_cntl_reg.h"
 #include "soc/rtc.h"
 #include "driver/rtc_io.h"
+#include "driver/i2c.h"
 
 
 // Sensor headers
@@ -103,10 +104,11 @@ void powerOffSequence();
 
 void setup() {
     setCpuFrequencyMhz(80);
-    Serial.begin(115200);
+    Serial.begin(921600);
     
-    Wire.begin(); // initialize early to ensure sensors can use it
+    //Wire.begin(); // initialize early to ensure sensors can use it
     // Initialize WiFi we need to continue even if wifi fails
+    Wire.begin(15, 16);
     WiFi.begin(SSID, PASSWD);
     if (WiFi.status() == WL_CONNECTED){
         String msg = SD_TAG + String (" WiFi connected");
@@ -114,9 +116,18 @@ void setup() {
         isConnected = true;
     }
 
+    int i2c_master_port = 0;
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = 15,         // select GPIO specific to your project
+        .scl_io_num = 16,         // select GPIO specific to your project
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .clk_flags = 0,                          // you can use I2C_SCLK_SRC_FLAG_* flags to choose i2c source clock here
+    };
+    i2c_driver_install(I2C_NUM_MAX, I2C_MODE_MASTER, 500, 500, 0);
     //setup spi 
-    SPI.begin(18, 19, 23, 5);
-    SPI.setDataMode(SPI_MODE0);
+    // SPI.begin(18, 19, 23, 5);
+    // SPI.setDataMode(SPI_MODE0);
 
     // Initialize sensors before wifi
     temp.begin();
@@ -130,16 +141,16 @@ void setup() {
     sensorMutex = xSemaphoreCreateMutex();
     
     // Initialize SD card
-    if(!SD.begin(SdSpiConfig(5, SHARED_SPI, SD_SCK_MHZ(16)))){
-        String msg = SD_TAG + String (" Card Mount Failed");
-        Serial.println(msg);
-        cardMount = false;
-    }
-    else  {
-        String msg = SD_TAG + String (" Card mount sucessful!");
-        Serial.println(msg);
-        cardMount = true;
-    }  
+    // if(!SD.begin(SdSpiConfig(5, SHARED_SPI, SD_SCK_MHZ(16)))){
+    //     String msg = SD_TAG + String (" Card Mount Failed");
+    //     Serial.println(msg);
+    //     cardMount = false;
+    // }
+    // else  {
+    //     String msg = SD_TAG + String (" Card mount sucessful!");
+    //     Serial.println(msg);
+    //     cardMount = true;
+    // }  
     
   
     //other system initializations

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ unsigned long lastUpdateTime = 0;
 const uint64_t SYSTEM_POWER_ON = 25 * MINUTE_US;
 volatile uint64_t USER_POWER_ON = 5 * HOUR_US;
 
-uint64_t SYSTEM_POWER_OFF = 5 * MINUTE_MS;  
+uint64_t SYSTEM_POWER_OFF = 30 * MINUTE_MS;  
 const uint64_t SENSOR_TASK_TIMER = HALF_MINUTE_MS; // 30 seconds, for tasks
 
 //tasks semaphores
@@ -105,7 +105,7 @@ void powerOffSequence();
 
 void setup() {
     setCpuFrequencyMhz(80);
-    Serial.begin(921600);
+    Serial.begin(115200);
     
     //Wire.begin(); // initialize early to ensure sensors can use it
     // Initialize WiFi we need to continue even if wifi fails
@@ -136,6 +136,8 @@ void setup() {
     phGloabl.begin();
     DO.begin();
     sal.begin(); //also tds & ec
+
+    //sal.calibrate();
 
     // Create mutexes
     sdCardMutex = xSemaphoreCreateMutex();

--- a/src/main_main.cpp
+++ b/src/main_main.cpp
@@ -37,10 +37,7 @@
 
 // Surveyor_pH pH = Surveyor_pH(35);
 
-
-
-// void uploadData(String data);
-
+// //void uploadData(String data);
 // void sdBegin();
 
 // // Status functions
@@ -58,8 +55,6 @@
 
 
 // void setup() {
-
-//     setCpuFrequencyMhz(80);
 //     Serial.begin(115200);
 //     Wire.begin();
 //     // Initialize SPIFFS
@@ -76,31 +71,27 @@
 //     // Initialize sensors
 //     temp.begin();
 //     tbdty.begin();
-//     //tbdty.calibrate();
+//     tbdty.calibrate();
 //     sal.begin();
 //     sal.EnableDisableSingleReading(SAL, 1);
-//     //sal.EnableDisableSingleReading(TDS,1);
+//     sal.EnableDisableSingleReading(TDS,1);
 //     DO.begin();
 //     phGloabl.begin();
 
-//     SPI.begin(18, 19, 23, 5);
-//     SPI.setDataMode(SPI_MODE0);
-//     if(!SD.begin(SdSpiConfig(5, SHARED_SPI, SD_SCK_MHZ(16)))){
-//         Serial.println("Card Mount Failed");
+//     // SPI.begin(18, 19, 23, 5);
+//     // SPI.setDataMode(SPI_MODE0);
+//     // if(!SD.begin(SdSpiConfig(5, SHARED_SPI, SD_SCK_MHZ(16)))){
+//     //     Serial.println("Card Mount Failed");
         
-//     }else   {
-//         Serial.println("Card mount sucessful!");
-//         cardMount = true;
-//     } 
+//     // }else   {
+//     //     Serial.println("Card mount sucessful!");
+//     //     cardMount = true;
+//     // } 
 
 //     // Initialize WiFi
-//     WiFi.begin(SSID, PASSWD);
+//     //WiFi.begin(SSID, PASSWD);
 
 //     rtc_begin();
-
-
-
-
 // }
 
 // void loop() {
@@ -131,27 +122,27 @@
 
 //     jsonPayload= prepareJsonPayload(data);
 //     csvPayLoad = prepareCSVPayload(data);
-//     saveDataToJSONFile(SD, jsonPayload);
-//     saveCSVData(SD, csvPayLoad);
+//     //saveDataToJSONFile(SD, jsonPayload);
+//     //saveCSVData(SD, csvPayLoad);
 
-//     printLocalTime();
+//     //printLocalTime();
 
 // }
 
 
-// void uploadData(String jsonData) {
-//     if (WiFi.status() == WL_CONNECTED) {
-//         Serial.println("Sending to Google.");
-//         // Serial.print(jsonData);
-//         HTTPClient http;
-//         http.begin(WEB_APP_URL);
-//         int httpResponseCode = http.POST(jsonData);
-//         http.addHeader("Content-Type", "application/json");
-//         http.end();
-//     } else {
-//         Serial.println("WiFi is not connected. Skipping data upload.");
-//     }
-// }
+// // void uploadData(String jsonData) {
+// //     if (WiFi.status() == WL_CONNECTED) {
+// //         Serial.println("Sending to Google.");
+// //         // Serial.print(jsonData);
+// //         HTTPClient http;
+// //         http.begin(WEB_APP_URL);
+// //         int httpResponseCode = http.POST(jsonData);
+// //         http.addHeader("Content-Type", "application/json");
+// //         http.end();
+// //     } else {
+// //         Serial.println("WiFi is not connected. Skipping data upload.");
+// //     }
+// // }
 
 
 // void blinkLED(int delayTime) {

--- a/src/oldMain.cpp
+++ b/src/oldMain.cpp
@@ -1,4 +1,24 @@
 // #include <Arduino.h>
+// #include <esp_adc_cal.h>
+// #include <esp32-hal-adc.h>
+
+// void setup() 
+// {
+//   Serial.begin(115200);
+//   analogReadResolution(12);
+//   pinMode(1, INPUT);  //GPIO4
+//   adcAttachPin(1);    //GPIO4
+
+// }
+
+// void loop() 
+// {
+//   int RawADC= adc1_get_raw(ADC1_CHANNEL_0); //GPIO9
+//   Serial.println(RawADC);
+//   delay(100);
+// }
+
+// #include <Arduino.h>
 
 // //required
 // #include <WiFi.h>
@@ -321,36 +341,36 @@
 // }
 
 
-// void loop() {
+// // void loop() {
     
 
-//     int buttonState = digitalRead(BUTTON_PIN);
-//     if(buttonState = LOW){
-//         tbdty.calibrate();
+// //     int buttonState = digitalRead(BUTTON_PIN);
+// //     if(buttonState = LOW){
+// //         tbdty.calibrate();
 
-//         //simple debounce
-//         while (digitalRead(BUTTON_PIN) == LOW) {
-//             delay(50);
-//         }
+// //         //simple debounce
+// //         while (digitalRead(BUTTON_PIN) == LOW) {
+// //             delay(50);
+// //         }
     
-//     }
+// //     }
 
-//     if (WiFi.status() == WL_CONNECTED) {
-//         // WiFi connected, set LED solid
-//         setLEDSolid(true);
-//     } else {
-//         // WiFi not connected
-//         if (WiFi.status() == WL_IDLE_STATUS) {
-//             // Initial connection attempt, blink twice
-//             blinkLED(200); // Short blink
-//             delay(200);
-//             blinkLED(200); // Short blink
-//             delay(200);
-//         } else {
-//             // WiFi connection failed, continue blinking
-//             blinkLED(500); // Blink every 500 ms
-//         }
-//     }
+// //     if (WiFi.status() == WL_CONNECTED) {
+// //         // WiFi connected, set LED solid
+// //         setLEDSolid(true);
+// //     } else {
+// //         // WiFi not connected
+// //         if (WiFi.status() == WL_IDLE_STATUS) {
+// //             // Initial connection attempt, blink twice
+// //             blinkLED(200); // Short blink
+// //             delay(200);
+// //             blinkLED(200); // Short blink
+// //             delay(200);
+// //         } else {
+// //             // WiFi connection failed, continue blinking
+// //             blinkLED(500); // Blink every 500 ms
+// //         }
+// //     }
 
-//     delay(100); // Add a small delay to prevent excessive CPU usage
-// }
+// //     delay(100); // Add a small delay to prevent excessive CPU usage
+// // }


### PR DESCRIPTION
Transferred all sensors to the new ESP32 board so we can use SIM chip and better SD card capabilities. Sensor pins have changed according the new breakout board designed for the new ESP32-S3. Added support for MCP23017 (GPIO extender).  Fully functioning sea wall with the new ESP32-S3 board.

Sensor pin changes:

PH
 - pin(35) -> pin(1)
 - EN(14) -> EN(40)

Temp and Humidity
 -  temp(33) -> temp(41)
 - hum(4) -> hum(42)

Turbidity
 - analogIn(32) -> analogIn(2)
 - EN(12) -> EN(39)

I2C Sensors:
 - SDA: 21 -> 15
 - SCL: 22 -> 16